### PR TITLE
update fix on parsing msgSend

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -497,9 +497,11 @@ impl ConvertSdkTx for InnerApp {
                     ));
                 }
 
-                let msg = &tx.body.messages[0];
+                let mut tx_data = tx.body.messages[0].clone();
+                let msg = &mut tx_data;
                 if msg.type_url.as_str() == "cosmos-sdk/MsgSend" {
                     use orga::cosmrs::tx::Msg;
+                    msg.type_url = "/cosmos.bank.v1beta1.MsgSend".to_string();
                     let msg =
                         MsgSend::from_any(msg).map_err(|_| Error::App("Invalid MsgSend".into()))?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -497,11 +497,9 @@ impl ConvertSdkTx for InnerApp {
                     ));
                 }
 
-                let mut tx_data = tx.body.messages[0].clone();
-                let msg = &mut tx_data;
-                if msg.type_url.as_str() == "cosmos-sdk/MsgSend" || msg.type_url.as_str() == "/cosmos.bank.v1beta1.MsgSend" {
+                let msg = &tx.body.messages[0];
+                if msg.type_url.as_str() == "/cosmos.bank.v1beta1.MsgSend" {
                     use orga::cosmrs::tx::Msg;
-                    msg.type_url = "/cosmos.bank.v1beta1.MsgSend".to_string();
                     let msg =
                         MsgSend::from_any(msg).map_err(|_| Error::App("Invalid MsgSend".into()))?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -499,7 +499,7 @@ impl ConvertSdkTx for InnerApp {
 
                 let mut tx_data = tx.body.messages[0].clone();
                 let msg = &mut tx_data;
-                if msg.type_url.as_str() == "cosmos-sdk/MsgSend" {
+                if msg.type_url.as_str() == "cosmos-sdk/MsgSend" || msg.type_url.as_str() == "/cosmos.bank.v1beta1.MsgSend" {
                     use orga::cosmrs::tx::Msg;
                     msg.type_url = "/cosmos.bank.v1beta1.MsgSend".to_string();
                     let msg =


### PR DESCRIPTION
## Why:
- After trying to send "cosmos-sdk/MsgSend" message through signDirect using cosmjs, i always face "invalid MsgSend"
## How:
- After debugging, i realize that MsgSend which is used in app.rs parse the msg use type_url  "/cosmos.bank.v1beta1.MsgSend". MsgSend on cosmrs only works on type_url i have said above, "cosmos-sdk/MsgSend" will fail check. That's why the error shows up
## Results: (here i using test-mainnet server for testing)
- Before:
![image](https://github.com/oraichain/bitcoin-bridge/assets/74671798/ca3ba6c5-f280-462e-a7c7-8091a996c978)
- Doing the Command:
![image](https://github.com/oraichain/bitcoin-bridge/assets/74671798/d8618ee3-b475-401f-ac6a-66c0ad85ac8b)
- After:
![image](https://github.com/oraichain/bitcoin-bridge/assets/74671798/d731c03b-d984-4f79-9fb6-d43207511cec)

## Other:
- Afternoon yesterday, Toan try send oraibtc on owallet but facing error: "Unsupported protobuf transaction" because of sending wrong type_url. I have fix this on signDirect
- You can test at: rpc: http://34.171.228.87:26657, rest: http://34.171.228.87:8001, chain-id: oraibtc-subnet-1
- Sample code test at https://github.com/perfogic/cosmwasm_deploy/blob/main/scripts/sample_send_with_sign_direct.ts for testing it first before merging to mainnet. Sequence info can be got from lcd.

