### PR TITLE
Fix migrate for new version

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -100,7 +100,7 @@ pub struct InnerApp {
 
 #[orga]
 impl InnerApp {
-    pub const CONSENSUS_VERSION: u8 = 11;
+    pub const CONSENSUS_VERSION: u8 = 12;
 
     #[call]
     pub fn deposit_rewards(&mut self) -> Result<()> {

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -74,7 +74,7 @@ pub const SIGSET_THRESHOLD: (u64, u64) = (9, 10);
 pub const SIGSET_THRESHOLD: (u64, u64) = (2, 3);
 
 /// The configuration parameters for the Bitcoin module.
-#[orga(skip(Default), version = 4)]
+#[orga(skip(Default), version = 6)]
 pub struct Config {
     /// The minimum number of checkpoints that must be produced before
     /// withdrawals are enabled.
@@ -110,24 +110,24 @@ pub struct Config {
     /// If a signer does not submit signatures for this many consecutive
     /// checkpoints, they are considered offline and are removed from the
     /// signatory set (jailed) and slashed.
-    #[orga(version(V1, V2, V3, V4, V5))]
+    #[orga(version(V1, V2, V3, V4, V5, V6))]
     pub max_offline_checkpoints: u32,
     /// The minimum number of confirmations a checkpoint must have on the
     /// Bitcoin network before it is considered confirmed. Note that in the
     /// current implementation, the actual number of confirmations required is
     /// `min_checkpoint_confirmations + 1`.
-    #[orga(version(V2, V3, V4, V5))]
+    #[orga(version(V2, V3, V4, V5, V6))]
     pub min_checkpoint_confirmations: u32,
     /// The maximum amount of BTC that can be held in the network, in satoshis.
-    #[orga(version(V2, V3, V4, V5))]
+    #[orga(version(V2, V3, V4, V5, V6))]
     pub capacity_limit: u64,
 
-    #[orga(version(V4))]
+    #[orga(version(V6))]
     pub max_deposit_age: u64,
 
-    #[orga(version(V4))]
+    #[orga(version(V6))]
     pub fee_pool_target_balance: u64,
-    #[orga(version(V4))]
+    #[orga(version(V6))]
     pub fee_pool_reward_split: (u64, u64),
 }
 
@@ -183,7 +183,7 @@ impl MigrateFrom<ConfigV2> for ConfigV3 {
             units_per_sat: value.units_per_sat,
             max_offline_checkpoints: value.max_offline_checkpoints,
             min_checkpoint_confirmations: 0,
-            capacity_limit: ConfigV4::default().capacity_limit,
+            capacity_limit: Config::bitcoin().capacity_limit,
         })
     }
 }
@@ -202,9 +202,49 @@ impl MigrateFrom<ConfigV3> for ConfigV4 {
             min_confirmations: value.min_confirmations,
             units_per_sat: value.units_per_sat,
             max_offline_checkpoints: value.max_offline_checkpoints,
+            min_checkpoint_confirmations: 0,
+            capacity_limit: Config::default().capacity_limit,
+        })
+    }
+}
+
+impl MigrateFrom<ConfigV4> for ConfigV5 {
+    fn migrate_from(value: ConfigV4) -> OrgaResult<Self> {
+        // Migrating to set min_checkpoint_confirmations to 0 and testnet
+        // capacity limit to 100 BTC
+        Ok(Self {
+            min_withdrawal_checkpoints: value.min_withdrawal_checkpoints,
+            min_deposit_amount: Config::default().min_deposit_amount,
+            min_withdrawal_amount: Config::default().min_withdrawal_amount,
+            max_withdrawal_amount: value.max_withdrawal_amount,
+            max_withdrawal_script_length: value.max_withdrawal_script_length,
+            transfer_fee: Config::default().transfer_fee,
+            min_confirmations: value.min_confirmations,
+            units_per_sat: value.units_per_sat,
+            max_offline_checkpoints: value.max_offline_checkpoints,
             min_checkpoint_confirmations: value.min_checkpoint_confirmations,
             capacity_limit: value.capacity_limit,
-            max_deposit_age: Self::default().max_deposit_age,
+        })
+    }
+}
+
+impl MigrateFrom<ConfigV5> for ConfigV6 {
+    fn migrate_from(value: ConfigV5) -> OrgaResult<Self> {
+        // Migrating to set min_checkpoint_confirmations to 0 and testnet
+        // capacity limit to 100 BTC
+        Ok(Self {
+            min_withdrawal_checkpoints: value.min_withdrawal_checkpoints,
+            min_deposit_amount: Config::default().min_deposit_amount,
+            min_withdrawal_amount: Config::default().min_withdrawal_amount,
+            max_withdrawal_amount: value.max_withdrawal_amount,
+            max_withdrawal_script_length: value.max_withdrawal_script_length,
+            transfer_fee: Config::default().transfer_fee,
+            min_confirmations: value.min_confirmations,
+            units_per_sat: value.units_per_sat,
+            max_offline_checkpoints: value.max_offline_checkpoints,
+            min_checkpoint_confirmations: value.min_checkpoint_confirmations,
+            capacity_limit: value.capacity_limit,
+            max_deposit_age: Config::default().max_deposit_age,
             fee_pool_target_balance: Config::default().fee_pool_target_balance,
             fee_pool_reward_split: Config::default().fee_pool_reward_split,
         })


### PR DESCRIPTION
Why:
- After merging to latest version of nomic, we made a mistake to overwrite the migrate file on bitcoin in mod.rs by chance. Which may lead to error in migrate step in our next version
- You can see our old mod.rs in bitcoin in version 1.1.4 here: https://github.com/oraichain/bitcoin-bridge/blob/407a978a3ca77816888ad4bf805270339084df1d/src/bitcoin/mod.rs
- Evidence for overwritten case: https://github.com/oraichain/bitcoin-bridge/compare/407a978a3ca77816888ad4bf805270339084df1d...e591ad43ce8fe35465ff58d1434bec9ec5f5be63#diff-c563e0484ecae29b63fe4e259c9a784c8d4507b1537cb370295f52a8b58d43afL76-R134