### PR TITLE
fix unhandled_confirm

### DIFF
--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -2389,10 +2389,15 @@ impl CheckpointQueue {
     }
 
     pub fn unhandled_confirmed(&self) -> Result<Vec<u32>> {
+        if self.confirmed_index.is_none() {
+            return Ok(vec![]);
+        }
+
         let mut out = vec![];
-        for i in self.first_unhandled_confirmed_cp_index..=self.index {
+        for i in self.first_unhandled_confirmed_cp_index..=self.confirmed_index.unwrap() {
             let cp = self.get(i)?;
-            if !matches!(cp.status, CheckpointStatus::Complete) || self.confirmed_index.is_none() {
+            if !matches!(cp.status, CheckpointStatus::Complete) {
+                log::warn!("Existing confirmed checkpoint without 'complete' status.");
                 break;
             }
             out.push(i);

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1097,7 +1097,7 @@ impl Bitcoin {
             confirmed_dests.push(dests);
         }
         if let Some(last_index) = unhandled_confirmed_cps.last() {
-            self.checkpoints.first_unhandled_confirmed_cp_index = *last_index;
+            self.checkpoints.first_unhandled_confirmed_cp_index = *last_index + 1;
         }
         Ok(confirmed_dests)
     }


### PR DESCRIPTION
## Why:
* Fix logic in handling unconfirmed checkpoint in take pending, to only take deposits of checkpoints which are already confirmed
## How:
* See in code changes.
## Results:
<img width="537" alt="image" src="https://github.com/oraichain/bitcoin-bridge/assets/74671798/6e1daf3a-9b2d-4ec6-ad89-698813ef56cf">
