### PR TITLE
add validate to should push and add more data to endpoints

### DIFF
--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -555,8 +555,8 @@ async fn bitcoin_value_locked() -> Value {
     })
 }
 
-#[get("/bitcoin/building_checkpoint_fee_info?<checkpoint_index>")]
-async fn building_checkpoint_fee_info(checkpoint_index: Option<u32>) -> Value {
+#[get("/bitcoin/checkpoint_fee_info?<checkpoint_index>")]
+async fn checkpoint_fee_info(checkpoint_index: Option<u32>) -> Value {
     let data = app_client()
         .query(|app: InnerApp| {
             let cp_index = checkpoint_index.unwrap_or(app.bitcoin.checkpoints.index);
@@ -1723,7 +1723,7 @@ fn rocket() -> _ {
             bitcoin_minimum_deposit,
             bitcoin_minimum_withdrawal,
             last_completed_checkpoint_tx,
-            building_checkpoint_fee_info
+            checkpoint_fee_info
         ],
     )
 }

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -555,12 +555,16 @@ async fn bitcoin_value_locked() -> Value {
     })
 }
 
-#[get("/bitcoin/building_checkpoint_fee_info")]
-async fn building_checkpoint_fee_info() -> Value {
+#[get("/bitcoin/building_checkpoint_fee_info?<checkpoint_index>")]
+async fn building_checkpoint_fee_info(checkpoint_index: Option<u32>) -> Value {
     let data = app_client()
         .query(|app: InnerApp| {
-            let fees_collected = app.bitcoin.checkpoints.building()?.fees_collected;
-            let miner_fee = app.bitcoin.checkpoints.query_building_miner_fee([0; 32])?;
+            let cp_index = checkpoint_index.unwrap_or(app.bitcoin.checkpoints.index);
+            let fees_collected = app.bitcoin.checkpoints.get(cp_index)?.fees_collected;
+            let miner_fee = app
+                .bitcoin
+                .checkpoints
+                .query_building_miner_fee(cp_index, [0; 32])?;
             Ok((fees_collected, miner_fee))
         })
         .await

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -138,7 +138,7 @@ async fn validators(status: Option<String>) -> Value {
                  "key": base64::encode(cons_key)
              },
              "jailed": validator.jailed,
-             "status": validator_status, 
+             "status": validator_status,
              "tokens": validator.amount_staked.to_string(),
              "delegator_shares": validator.amount_staked.to_string(),
              "description": {
@@ -552,6 +552,23 @@ async fn bitcoin_value_locked() -> Value {
 
     json!({
         "value": value_locked
+    })
+}
+
+#[get("/bitcoin/building_checkpoint_fee_info")]
+async fn building_checkpoint_fee_info() -> Value {
+    let data = app_client()
+        .query(|app: InnerApp| {
+            let fees_collected = app.bitcoin.checkpoints.building()?.fees_collected;
+            let miner_fee = app.bitcoin.checkpoints.query_building_miner_fee([0; 32])?;
+            Ok((fees_collected, miner_fee))
+        })
+        .await
+        .unwrap();
+
+    json!({
+        "fees_collected": data.0,
+        "miner_fee": data.1
     })
 }
 
@@ -1701,7 +1718,8 @@ fn rocket() -> _ {
             bitcoin_sigset_with_index,
             bitcoin_minimum_deposit,
             bitcoin_minimum_withdrawal,
-            last_completed_checkpoint_tx
+            last_completed_checkpoint_tx,
+            building_checkpoint_fee_info
         ],
     )
 }


### PR DESCRIPTION
## Why:
* This one will validate always the case that input amount always has to be "greater than" output amount + fee.
* I add more field  **first_unhandled_confirmed_cp_index** for us to monitor our nodes.
* I add a field **transaction_hash** on **bitcoin/checkpoint**, to debug old checkpoint on bitcoin network.
## How:
* See in code changes.
## Test:
* I already test with all testcases, and get the results passed.